### PR TITLE
install perltidy script in bindir

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,6 +12,6 @@ WriteMakefile(
         : ()
     ),
 
-    #EXE_FILES => ['bin/perltidy'],
+    EXE_FILES => ['bin/perltidy'],
     dist => { COMPRESS => 'gzip', SUFFIX => 'gz' },
 );


### PR DESCRIPTION
Prior version of perltidy installed perl script in bindir,
this feature was disabled sometime prior to github migration.

Install perltidy in bindir by default (solves perltidy/perltidy#1)