### PR TITLE
Add pre-commit hook config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: perltidy
+  name: perltidy
+  description: Run the perltidy source code formatter on Perl source files
+  minimum_pre_commit_version: 2.1.0
+  entry: perltidy --nostandard-output --backup-and-modify-in-place
+  args: [--standard-error-output, --backup-file-extension=/]
+  language: perl
+  types: [perl]


### PR DESCRIPTION
pre-commit 2.1.0 was just released with support for installing perl hooks: https://pre-commit.com/#perl

This adds configuration people can use to easily add perltidy in their pre-commit configs. There are other pre-commit configs for perltidy around, but this uses the native installation capability meaning people don't have to bother installing perltidy, it will get pulled in automatically, and respect the revision specified in the config.

To test, install pre-commit, create this config to the top level of a git repository somewhere containing perl files as `.pre-commit-config.yaml` (no need to add or commit it, just create the file), and run `pre-commit run perltidy --all-files`.
```yaml
repos:
  - repo: https://github.com/scop/perltidy
    rev: 024ba4f4b9850cc8071749bb65f6488b91ccd7c2
    hooks:
      - id: perltidy
```

Later, if/when this is part of perltidy proper, the config will be similar, just with the official repo URL and revision as appropriate. (For the revision BTW, git hashes work, but having release versions tagged in the perltidy repo would be more user friendly and good to have and useful otherwise as well.)