### PR TITLE
fix exit status for assert-tidy/untidy options

### DIFF
--- a/lib/Perl/Tidy.pm
+++ b/lib/Perl/Tidy.pm
@@ -1528,6 +1528,7 @@ EOM
                     $logger_object->interrupt_logfile();
                     $logger_object->warning( $diff_msg . "\n" );
                     $logger_object->resume_logfile();
+                    $Warn_count++;
                 }
             }
             if ( $rOpts->{'assert-untidy'} ) {
@@ -1536,6 +1537,7 @@ EOM
                     $logger_object->warning(
 "assertion failure: '--assert-untidy' is set but output equals input\n"
                     );
+                    $Warn_count++;
                 }
             }
 


### PR DESCRIPTION
According to the documentation, `--assert-tidy` or `--assert-untidy` option can cause the process to return a non-zero exit code.

but current implementation always return 0 even if input and output code identical or not.

Signed-off-by: Ji-Hyeon Gim <potatogim@potatogim.net>