### PR TITLE
Fix MSWin32 EOL translation without UTF-8 in backup-mode

### DIFF
--- a/lib/Perl/Tidy.pm
+++ b/lib/Perl/Tidy.pm
@@ -1315,9 +1315,8 @@ sub backup_method_copy {
 "problem re-opening $input_file for write for -b option; check file and directory permissions: $OS_ERROR\n"
       );
 
-    if ( $self->[_is_encoded_data_] ) {
-        binmode $fout, ":raw:encoding(UTF-8)";
-    }
+    if ( $self->[_is_encoded_data_] ) { binmode $fout, ":raw:encoding(UTF-8)" }
+    else                              { binmode $fout }
 
     # Now copy the formatted output to it..
     # output must be SCALAR ref..
@@ -1454,9 +1453,8 @@ sub backup_method_move {
 "problem re-opening $input_file for write for -b option; check file and directory permissions: $OS_ERROR\n"
       );
 
-    if ( $self->[_is_encoded_data_] ) {
-        binmode $fout, ":raw:encoding(UTF-8)";
-    }
+    if ( $self->[_is_encoded_data_] ) { binmode $fout, ":raw:encoding(UTF-8)" }
+    else                              { binmode $fout }
 
     # Now copy the formatted output to it..
     # output must be SCALAR ref..


### PR DESCRIPTION
On Windows machines, the CRLF translation layer was left in-place, when using the backup (-b) without the utf8-ecoding (-enc=utf8) option, which causes the output file to be converted to "DOS" CRLF line endings, even with the -ole=unix setting enabled.

Added `binmode` call in `backup_method_move` and `backup_method_copy` to disable the CRLF translation layer, in the case of none-encoded-data, as it is already used in `PATH 3b: output to a named file`.