### PR TITLE
remove broken logic line in Perl::Tidy::Logger

### DIFF
--- a/lib/Perl/Tidy/Logger.pm
+++ b/lib/Perl/Tidy/Logger.pm
@@ -516,7 +516,6 @@ sub finish {
             my $routput_array = $self->{_output_array};
             foreach my $line ( @{$routput_array} ) { $fh->print($line) }
             if (   $fh->can('close')
-                && !ref($log_file) ne '-'
                 && $log_file ne '-' )
             {
                 $fh->close()


### PR DESCRIPTION
As caught by a new Perl warning, this line has incorrect precedence; it is comparing !ref($log_file) (which can only be '1' or '') with '-' so it will always be true. Additionally, if it was meant to be !(ref($log_file) ne '-') that would be equivalent to ref($log_file) eq '-' which would always be false unless an object is blessed to the class '-', so just remove this line because it doesn't make sense.