### PR TITLE
Add default list of stages for pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,9 @@
 - id: perltidy
   name: perltidy
   description: Run the perltidy source code formatter on Perl source files
-  minimum_pre_commit_version: 2.1.0
   entry: perltidy --nostandard-output --backup-and-modify-in-place
   args: [--standard-error-output, --backup-file-extension=/]
   language: perl
   types: [perl]
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
+  minimum_pre_commit_version: 3.2.0 # for "new" names in stages


### PR DESCRIPTION
The pre-commit default of running in all possible stages is not quite optimal for perltidy. Follow upstream advice:

https://pre-commit.com/#confining-hooks-to-run-at-certain-stages

> If you are authoring a tool, it is usually a good idea to provide an
> appropriate stages property. For example a reasonable setting for a
> linter or code formatter would be stages:
> [pre-commit, pre-merge-commit, pre-push, manual].