### PR TITLE
Suppress 'Possible attempt to escape whitespace' warnings

### DIFF
--- a/lib/Perl/Tidy/Formatter.pm
+++ b/lib/Perl/Tidy/Formatter.pm
@@ -4702,7 +4702,10 @@ sub initialize_whitespace_hashes {
       **= &&= ||= //= <=> A k f w F n C Y U G v P S ^^
       #;
 
-    my @spaces_left_side = qw< t ! ~ m p { \ h pp mm Z j >;
+      #my @spaces_left_side = qw< t ! ~ m p { \ h pp mm Z j >;
+    my @spaces_left_side = qw< t ! ~ m p { >;
+    push @spaces_left_side, "\\";
+    push @spaces_left_side, qw< h pp mm Z j >;
     push( @spaces_left_side, '#' );    # avoids warning message
 
     # c349: moved **= from @spaces_right_side to @spaces_both_sides

--- a/lib/Perl/Tidy/Formatter.pm
+++ b/lib/Perl/Tidy/Formatter.pm
@@ -5735,8 +5735,9 @@ EOM
 
         # These are the only characters which can (currently) form special
         # variables, like $^W: (issue c066, c068).
-        @q =
-          qw{ ? A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _ };
+        @q = qw{ ? A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ };
+        push @q, "\\";
+        push @q, ( qw{  ] ^ _ } );
         @is_special_variable_char{@q} = (1) x scalar(@q);
 
         @q = qw( 0 1 2 3 4 5 6 7 8 9 );
@@ -15993,7 +15994,11 @@ BEGIN {
       .. :: << >> ** && .. || // -> => += -= .= %= &= |= ^= *= <>
       ( ) <= >= == =~ !~ != ++ -- /= x=
       ... **= <<= >>= &&= ||= //= <=>
-      + - / * | % ! x ~ = \ ? : . < > ^ &
+      + - / * | % ! x ~ =
+      #;
+    push @q, "\\";
+    push @q, qw#
+      ? : . < > ^ &
       #;
     push @q, ',';
     @is_ascii_type{@q} = (1) x scalar(@q);

--- a/lib/Perl/Tidy/Tokenizer.pm
+++ b/lib/Perl/Tidy/Tokenizer.pm
@@ -8855,8 +8855,9 @@ sub do_scan_package {
 
         # These are the only characters which can (currently) form special
         # variables, like $^W: (issue c066).
-        my @q =
-          qw{ ? A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ \ ] ^ _ };
+        my @q = qw{ ? A B C D E F G H I J K L M N O P Q R S T U V W X Y Z [ };
+        push @q, "\\";
+        push @q, qw{ ] ^ _ };
         @is_special_variable_char{@q} = (1) x scalar(@q);
     } ## end BEGIN
 

--- a/lib/Perl/Tidy/Tokenizer.pm
+++ b/lib/Perl/Tidy/Tokenizer.pm
@@ -6837,7 +6837,11 @@ BEGIN {
     # after package NAMESPACE, so expecting TERM)
     # Fix for c250: add new type 'S' for sub (not expecting operator)
     my @q = qw#
-      ; ! + x & ?  F J - p / Y : % f U ~ A G j L P S * . | ^ < = [ m { \ > t
+      ; ! + x & ?  F J - p / Y : % f U ~ A G j L P S * . | ^ < = [ m {
+      #;
+    push @q, "\\";
+    push @q, qw#
+      > t
       || >= != mm *= => .. !~ == && |= .= pp -= =~ += <= %= ^= x= ~~ ** << /=
       &= // >> ~. &. |. ^.
       ... **= <<= >>= &&= ||= //= <=> !~~ &.= |.= ^.= <<~

--- a/lib/Perl/Tidy/Tokenizer.pm
+++ b/lib/Perl/Tidy/Tokenizer.pm
@@ -11736,9 +11736,17 @@ BEGIN {
     # make a hash of all valid token types for self-checking the tokenizer
     # (adding NEW_TOKENS : select a new character and add to this list)
     # fix for c250: added new token type 'P' and 'S'
+#    my @valid_token_types = qw#
+#      A b C G L R f h Q k t w i q n p m F pp mm U j J Y Z v P S
+#      { } ( ) [ ] ; + - / * | % ! x ~ = \ ? : . < > ^ &
+#      #;
     my @valid_token_types = qw#
       A b C G L R f h Q k t w i q n p m F pp mm U j J Y Z v P S
-      { } ( ) [ ] ; + - / * | % ! x ~ = \ ? : . < > ^ &
+      { } ( ) [ ] ; + - / * | % ! x ~ =
+      #;
+    push @valid_token_types, "\\";
+    push @valid_token_types, qw#
+      ? : . < > ^ &
       #;
     push( @valid_token_types, @digraphs );
     push( @valid_token_types, @trigraphs );

--- a/lib/Perl/Tidy/Tokenizer.pm
+++ b/lib/Perl/Tidy/Tokenizer.pm
@@ -11736,10 +11736,6 @@ BEGIN {
     # make a hash of all valid token types for self-checking the tokenizer
     # (adding NEW_TOKENS : select a new character and add to this list)
     # fix for c250: added new token type 'P' and 'S'
-#    my @valid_token_types = qw#
-#      A b C G L R f h Q k t w i q n p m F pp mm U j J Y Z v P S
-#      { } ( ) [ ] ; + - / * | % ! x ~ = \ ? : . < > ^ &
-#      #;
     my @valid_token_types = qw#
       A b C G L R f h Q k t w i q n p m F pp mm U j J Y Z v P S
       { } ( ) [ ] ; + - / * | % ! x ~ =
@@ -11923,7 +11919,11 @@ BEGIN {
     my @value_requestor_type = qw#
       L { ( [ ~ !~ =~ ; . .. ... A : && ! || // = + - x
       **= += -= .= /= *= %= x= &= |= ^= <<= >>= &&= ||= //=
-      <= >= == != => \ > < % * / ? & | ** <=> ~~ !~~ <<~
+      <= >= == != =>
+      #;
+    push @value_requestor_type, "\\";
+    push @value_requestor_type, qw#
+      > < % * / ? & | ** <=> ~~ !~~ <<~
       f F pp mm Y p m U J G j >> << ^ t
       ~. ^. |. &. ^.= |.= &.= ^^
       #;


### PR DESCRIPTION
A change in the Perl 5 core distribution's main development branch (`blead`) is causing Perl-Tidy to emit copious warnings.  As of perl-5.43.2 these warnings are clogging up Perl-Tidy's CPANtesters reports and are causing some other CPAN distributions which are dependent upon Perl-Tidy to also emit warnings and in some cases fail outright.  This pull request should silence the warnings in Perl-Tidy going forward (without having an unfavorable impact on Perl-Tidy's behavior on perls up through perl-5.42) and enable those downstream libraries to once again pass on CPANtesters.

**The Change in Perl 5 Blead**
```
commit f347ee8958f6c6bbb4a7f13dbe951f1ac0f14efb
Author: Philippe Bruhat (BooK) <book@cpan.org>
Date:   Fri Jul 4 19:30:32 2025 +0200
Commit:     Philippe Bruhat (BooK) <book@cpan.org>
CommitDate: Mon Aug 18 09:26:10 2025 +0200

    add a new warning against using \ in qw()
```
You can see the discussion that led to this change in https://github.com/Perl/perl5/pull/23403.  Having been committed on August 18, this is effective as of development release perl-5.43.2.

**The Impact on Perl-Tidy**

See, *e.g.,* https://www.cpantesters.org/cpan/report/7bcebb8a-7e27-11f0-8fb7-f0deb4906850.

**The Impact of the Change on CPAN Distributions**

Example: Impact on Perl-Critic:
See report https://www.cpantesters.org/cpan/report/d6943646-8d66-11f0-a320-c33afab345f4
Below is what I myself got locally today:
```
Running Build test for PETDANCE/Perl-Critic-1.156.tar.gz
t/00_modules.t ................................ Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/PPIx/Regexp/Token/Literal.pm line 205.

Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Formatter.pm line 4645.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Formatter.pm line 5678.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Formatter.pm line 15816.

Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Tokenizer.pm line 6839.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Tokenizer.pm line 8848.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Tokenizer.pm line 11730.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Tokenizer.pm line 11909.
```

Example: Impact on Perl-Critic-StricterSubs
See report https://www.cpantesters.org/cpan/report/5657b5f2-8e4c-11f0-8da9-87eb6760838f
Below is what I myself got locally today:

```
Running Build test for PETDANCE/Perl-Critic-StricterSubs-0.08.tar.gz
File 'MANIFEST.SKIP' does not exist: Creating a temporary 'MANIFEST.SKIP'
t/20_policies.t .. Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/PPIx/Regexp/Token/Literal.pm line 205.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Formatter.pm line 4645.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Formatter.pm line 5678.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Formatter.pm line 15816.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Tokenizer.pm line 6839.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Tokenizer.pm line 8848.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Tokenizer.pm line 11730.
Possible attempt to escape whitespace in qw() list at /home/jkeenan/testing/blead/lib/perl5/site_perl/5.43.3/Perl/Tidy/Tokenizer.pm line 11909.
t/20_policies.t .. 1/76 
#   Failed test 'no (unexpected) warnings (via END block)'
#   at /home/jkeenan/testing/blead/lib/perl5/5.43.3/Test/Builder.pm line 187.
# Looks like you failed 1 test of 76.
t/20_policies.t .. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/76 subtests 

Test Summary Report
-------------------
t/20_policies.t (Wstat: 256 (exited 1) Tests: 76 Failed: 1)
  Failed test:  76
  Non-zero exit status: 1
Files=1, Tests=76,  0 wallclock secs ( 0.01 usr  0.00 sys +  0.40 cusr  0.03 csys =  0.44 CPU)
Result: FAIL
Failed 1/1 test programs. 1/76 subtests failed.
  PETDANCE/Perl-Critic-StricterSubs-0.08.tar.gz
  ./Build test -- NOT OK
```
Please review.

Thank you very much.

@BooK @petdance
