### PR TITLE
Build and publish Docker images for development version tags too

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]"
+      - "[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9].[0-9][0-9]"
 
 permissions: {}
 
@@ -34,5 +35,8 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/ppc64le,linux/riscv64,linux/s390x
           tags: |
             ghcr.io/${{ github.repository_owner }}/perltidy:${{ github.ref_name }}
-            ghcr.io/${{ github.repository_owner }}/perltidy:latest
+            ${{ case(
+                contains(github.ref_name,'.'), '',
+                format('ghcr.io/{0}/perltidy:latest', github.repository_owner)
+            ) }}
           push: true


### PR DESCRIPTION
Ref https://github.com/perltidy/perltidy/pull/199

Always publish images tagged with the version, but do not tag development version images as `latest`, as that's likely not what users of that tag expect. Only release tags are marked `latest`.